### PR TITLE
Update default Nitro host

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ generateXmlSource.dependsOn createGeneratedSourcesDir
 task fetchApiDescription {
     doLast {
         ant.get(
-            src: "http://d.bbc.co.uk/nitro/api?api_key="+System.properties['nitro.apikey'],
+            src: "http://programmes.api.bbc.com/nitro/api?api_key="+System.properties['nitro.apikey'],
             dest: new File('src/main/resources')
         ) {
             mapper(type:"regexp", from:".*api\\?.*",to:"api.xml")

--- a/src/main/java/com/metabroadcast/atlas/glycerin/XmlGlycerin.java
+++ b/src/main/java/com/metabroadcast/atlas/glycerin/XmlGlycerin.java
@@ -16,7 +16,7 @@ import com.metabroadcast.atlas.glycerin.queries.VersionsQuery;
 
 public class XmlGlycerin implements Glycerin {
     
-    private static final String DEFAULT_HOST = "d.bbc.co.uk";
+    private static final String DEFAULT_HOST = "programmes.api.bbc.com";
     
     public static Builder builder(String apiKey) {
         return new Builder(apiKey);


### PR DESCRIPTION
As of 24/12/2015 the following hosts have been deprecated:

d.bbc.co.uk
data.bbc.co.uk
nitro.api.bbci.co.uk

and replaced by

programmes.api.bbc.com

See api.xml/deprecations

````xml
  <n:deprecations>
    <n:deprecated name="nitro.api.bbci.co.uk" type="host" deprecated_since="2015-12-24" replaced_by="programmes.api.bbc.com" replacement_type="host"/>
    <n:deprecated name="data.bbc.co.uk" type="host" deprecated_since="2015-12-24" replaced_by="programmes.api.bbc.com" replacement_type="host"/>
    <n:deprecated name="d.bbc.co.uk" type="host" deprecated_since="2015-12-24" replaced_by="programmes.api.bbc.com" replacement_type="host"/>
  </n:deprecations>
````