### PR TITLE
Make .withUnsafeArbitrary take varargs instead of just one value

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven'
 sourceCompatibility = 1.7
 
 group 'com.metabroadcast.atlas.glycerin'
-version = '2.1.2'
+version = '2.1.3'
 
 task wrapper(type: Wrapper) {
     gradleVersion = '2.8'

--- a/src/queries/java/com/metabroadcast/atlas/glycerin/generator/FeedQueryGenerator.java
+++ b/src/queries/java/com/metabroadcast/atlas/glycerin/generator/FeedQueryGenerator.java
@@ -146,17 +146,24 @@ public class FeedQueryGenerator {
         return bldrCls;
     }
 
+    // TODO: MBST-15453.
+    /* This is a hack to work around us not supporting overloaded availability queries. Nitro
+    supports both enums and ISO8601 durations, we only support enums. Adding enums is hard, adding
+    this is simple.
+     */
     private void addUnsafeUrlArg(JDefinedClass bldrCls, JVar paramBuilder) {
         JMethod method = bldrCls.method(JMod.PUBLIC, bldrCls, "withUnsafeArbitrary");
         JVar nameParam = method.param(String.class, "name");
-        JVar valueParam = method.param(String.class, "value");
+        JVar valueParam = method.varParam(String.class, "values");
 
         JBlock mthdBody = method.body();
 
-        JInvocation putIntoMap = paramBuilder.invoke("put")
-                .arg(nameParam)
-                .arg(precs.staticInvoke("checkNotNull").arg(valueParam));
-        mthdBody.add(putIntoMap);
+        mthdBody.add(
+                paramBuilder.invoke("put")
+                        .arg(nameParam)
+                        .arg(immutableList.staticInvoke("copyOf").arg(valueParam))
+        );
+
         mthdBody._return(JExpr._this());
     }
 


### PR DESCRIPTION
A number of Nitro endpoints use their argument values as a conjunction, rather than assuming any implied defaults. In this
particular case, availability=PT12H gets us the future items, but none of the already available ones. We need both
'available' *and* 'PT12H'. The previous implementation only supported doing one at a time.