### PR TITLE
fix test for scheduled_start

### DIFF
--- a/src/test/java/com/metabroadcast/atlas/glycerin/GlycerinIntegrationTest.java
+++ b/src/test/java/com/metabroadcast/atlas/glycerin/GlycerinIntegrationTest.java
@@ -239,11 +239,15 @@ public class GlycerinIntegrationTest {
 
     private Long obtainScheduledStartTime(AvailableVersions availableVersions) {
         try {
-            AvailableVersions.Version version = availableVersions.getVersion().get(0);
-            AvailableVersions.Version.Availabilities availability = version.getAvailabilities().get(0);
-            return availability.getAvailableVersionsAvailability().get(0).getScheduledStart().toGregorianCalendar().getTimeInMillis();
-        } catch (Exception e) {
-            return null;
-        }
+            for( AvailableVersions.Version av: availableVersions.getVersion()){
+                for (AvailableVersions.Version.Availabilities aa: av.getAvailabilities())   {
+                    for(AvailableVersions.Version.Availabilities.Availability a: aa.getAvailableVersionsAvailability()) {
+                        if ("future".equals(a.getStatus())) continue;
+                        return a.getScheduledStart().toGregorianCalendar().getTimeInMillis();
+                    }
+                }
+            }
+        } catch (Exception e) {}
+        return null;
     }
 }

--- a/src/test/java/com/metabroadcast/atlas/glycerin/GlycerinIntegrationTest.java
+++ b/src/test/java/com/metabroadcast/atlas/glycerin/GlycerinIntegrationTest.java
@@ -242,7 +242,9 @@ public class GlycerinIntegrationTest {
             for( AvailableVersions.Version av: availableVersions.getVersion()){
                 for (AvailableVersions.Version.Availabilities aa: av.getAvailabilities())   {
                     for(AvailableVersions.Version.Availabilities.Availability a: aa.getAvailableVersionsAvailability()) {
-                        if ("future".equals(a.getStatus())) continue;
+                        if ("future".equals(a.getStatus())) {
+                            continue;
+                        }
                         return a.getScheduledStart().toGregorianCalendar().getTimeInMillis();
                     }
                 }


### PR DESCRIPTION
the test failed due to wrong retrieval of scheduled_start from available versions
an episode can contain more than 1 available version with 2 types : available and future
actually we need to filter all available versions based on type=available
filter out all those with status=future